### PR TITLE
Fix JSON naming for frontend

### DIFF
--- a/Controllers/CoursesController.cs
+++ b/Controllers/CoursesController.cs
@@ -22,11 +22,22 @@ namespace LMS_ManagementAPI.Controllers
                 return new List<Course>();
 
             var json = System.IO.File.ReadAllText(FilePath);
-            return JsonSerializer.Deserialize<List<Course>>(json) ?? new List<Course>();
+            return JsonSerializer.Deserialize<List<Course>>(json,
+                new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                }) ?? new List<Course>();
         }
 
         private static void SaveToFile() =>
-            System.IO.File.WriteAllText(FilePath, JsonSerializer.Serialize(_courses, new JsonSerializerOptions { WriteIndented = true }));
+            System.IO.File.WriteAllText(FilePath,
+                JsonSerializer.Serialize(
+                    _courses,
+                    new JsonSerializerOptions
+                    {
+                        WriteIndented = true,
+                        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                    }));
 
         [HttpGet]
         public ActionResult<IEnumerable<Course>> GetCourses() => _courses;

--- a/Program.cs
+++ b/Program.cs
@@ -6,9 +6,13 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Text.Json;
 
 var builder = WebApplication.CreateBuilder(args);
-builder.Services.AddControllers();
+builder.Services.AddControllers().AddJsonOptions(o =>
+{
+    o.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+});
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c => {
     c.SwaggerDoc("v1", new OpenApiInfo { Title = "LMS API", Version = "v1" });


### PR DESCRIPTION
## Summary
- ensure API uses camelCase JSON naming
- deserialize with case-insensitive names

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614447abe083218b89c9884d793655